### PR TITLE
spdf: Fix outdated python resource specification

### DIFF
--- a/spdf.rb
+++ b/spdf.rb
@@ -5,7 +5,11 @@ class Spdf < Formula
   head "https://github.com/baskerville/spdf.git"
 
   depends_on "python@2"
-  depends_on "PyPDF2" => :python
+
+  resource "PyPDF2" do
+    url "https://files.pythonhosted.org/packages/b4/01/68fcc0d43daf4c6bdbc6b33cc3f77bda531c86b174cac56ef0ffdb96faab/PyPDF2-1.26.0.tar.gz"
+    sha256 "e28f902f2f0a1603ea95ebe21dff311ef09be3d0f0ef29a3e44a932729564385"
+  end
 
   def install
     bin.install "spdf.py" => "spdf"


### PR DESCRIPTION
Trying to tap the repo, got the error:
```
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/baskerville/homebrew-formulae/spdf.rb
Calling 'depends_on ... => :python' is disabled!
There is no replacement.
/usr/local/Homebrew/Library/Taps/baskerville/homebrew-formulae/spdf.rb:8:in `<class:Spdf>'
Please report this to the baskerville/formulae tap!
Or, even better, submit a PR to fix it!
Error: Cannot tap baskerville/formulae: invalid syntax in tap!
````

Noticed there was a fix two days ago for the similar problem, but, obviously, it's not fixed that.